### PR TITLE
Remove eslint-plugin-vue from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A set of opinionated ESLint (http://eslint.org) rules (all rules included) tailo
 
 ```js
 {
-  "extends": "vue"
+  "extends": "vue",
+  "plugins": ["vue"],
   // Your overrides...
 }
 ```

--- a/index.js
+++ b/index.js
@@ -13,8 +13,6 @@ module.exports = {
     node: true
   },
 
-  plugins: ['vue'],
-
   globals: {
     document: false,
     navigator: false,
@@ -135,7 +133,6 @@ module.exports = {
     'prefer-const': 2,
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
     'object-curly-spacing': [2, 'always', { objectsInObjects: false }],
-    'array-bracket-spacing': [2, 'never'],
-    'vue/jsx-uses-vars': 2
+    'array-bracket-spacing': [2, 'never']
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/vuejs/eslint-config-vue#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0",
-    "eslint-plugin-vue": "^1.0.0"
+    "eslint": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
[eslint-plugin-html v2](https://github.com/BenoitZugmeyer/eslint-plugin-html/tree/v2) (support for --fix) is not compatible with eslint-plugin-vue. Forcing eslint-plugin-vue, makes eslint-config-vue unusable.


Related vuejs/eslint-plugin-vue#3